### PR TITLE
use Buffer instead of text-encoding to reduce bundle size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
-var TextEncoder = require('text-encoding');
-	zlib = require('jszlib'),
+var zlib = require('jszlib'),
 	bufferArrayTypes = require('enum-buffer-array-types');
-
-var utf8Decoder = new TextDecoder('utf-8');
 
 function enumName(val) {
 	var typeName = 'unknown';
@@ -42,7 +39,7 @@ function decodeToGeometry(buffer, inflate) {
 		advanceCursor(nameLength);
 
 		var nameBuffer = new Uint8Array(sliceBuffer());
-		var name = utf8Decoder.decode(nameBuffer);
+		var name = new Buffer(nameBuffer, 'utf8').toString();
 		if(debugLevel >= 2) console.group(name);
 
 		advanceCursor(4);

--- a/package.json
+++ b/package.json
@@ -11,8 +11,7 @@
   },
   "dependencies": {
     "enum-buffer-array-types": "^2.0.1",
-    "jszlib": "git://github.com/dasmoth/jszlib",
-    "text-encoding": "^0.5.2"
+    "jszlib": "git://github.com/dasmoth/jszlib"
   },
   "devDependencies": {
     "loadandrunscripts": "^1.0.0",


### PR DESCRIPTION
Buffer is a Node API which is shimmed in automatically by browserify

this drops the bundle size by about 500kb (after minification)
